### PR TITLE
content: Publish INTEL-20/21 — Vendor Pressure Audit + Contract Restructuring

### DIFF
--- a/content/intel/intel-20-vendor-pressure-audit.md
+++ b/content/intel/intel-20-vendor-pressure-audit.md
@@ -1,0 +1,55 @@
+---
+title: "INTEL-20: The Vendor Pressure Audit"
+description: "Most enterprises are already inside the AI-defender coalition — at one degree of separation, through their existing security stack. Glasswing partners include AWS, CrowdStrike, JPMorgan Chase, Microsoft, Palo Alto and others; OpenAI's TAC scales to thousands of verified defenders. Vendors aren't volunteering when coalition-derived AI defensive capability arrives in your existing license. The action: add a single recurring agenda item to every security-vendor QBR — what's your timeline, and what's the mechanism?"
+date: 2026-04-29
+type: "intel"
+intel_type: "TREND"
+tags: ["Vendor Management", "Procurement", "AI Defense", "Glasswing", "Trusted Access for Cyber", "CISO", "QBR", "Coalition", "License Management", "Risk Management", "Board Governance"]
+---
+
+## The INTEL
+
+**Most enterprises are already inside the AI-defender coalition — at one degree of separation. Almost no security vendor will surface this unprompted.**
+
+Project Glasswing's launch partners include AWS, Apple, Broadcom, Cisco, **CrowdStrike**, Google, **JPMorgan Chase**, the Linux Foundation, **Microsoft**, NVIDIA, and **Palo Alto Networks**. OpenAI's Trusted Access for Cyber (TAC) program scales to "thousands of verified individual defenders and hundreds of teams responsible for defending critical software." If your enterprise licenses Defender, Falcon, Cortex, Chronicle, AWS Security Hub, or Cisco Security, you have already paid for seats at the coalition table — through your existing vendor relationship.
+
+The vendors aren't volunteering when coalition-derived AI defensive capability arrives in your existing license. Most CISO QBR agendas have not yet caught up to the question. The April 16–23 inflection landed less than two weeks ago; the procurement cycle response is still ahead of the market.
+
+---
+
+## Why It Matters
+
+The Wiz 2026 CISO survey found that **58% of organizations run 25 or more security tools**. Tool sprawl was last quarter's meta-risk. This quarter, it's also the meta-leverage — every one of those 25+ vendor relationships is potentially a coalition-derived AI defender uplift waiting to be activated, *if* you ask. Most won't be activated by default. Most will arrive bundled into a premium SKU at the next renewal, monetized rather than upgraded.
+
+The asymmetry is procedural, not technical. The vendor knows their roadmap. The buyer doesn't — until the renewal cycle. Asking the question now, while the inflection is still news, surfaces capability you may already be entitled to under your current license terms.
+
+---
+
+## What To Do — One Key Action
+
+**Add a single recurring agenda item to every security-vendor QBR starting this quarter:**
+
+> *"What is your timeline for shipping Glasswing- or TAC-derived AI defensive capability into our existing license tier — and what is the mechanism: feature flag, tier upgrade, separate SKU, or public roadmap?"*
+
+The question is the work. Vendors that are coalition members will have an answer, or will surface that they do not yet have one. Both responses are useful — the answer informs your AI roadmap; the silence informs your renewal posture.
+
+This is a governance lever that procurement, CISO, and FP&A functions can pull together. Document the responses across the vendor stack. Use them at the next renewal. The vendors that ship coalition-derived capability into existing tiers earn renewal velocity. The vendors that gate it behind a premium SKU earn additional procurement scrutiny — *and* market signal that buyers are watching.
+
+---
+
+## MITRE ATT&CK
+
+- **T1199 — Trusted Relationship:** The vendor channel itself is a trust relationship at the technical level. The April inflection introduces a new dimension to that relationship — *defender uplift propagation* — that the trust audit must now include.
+
+---
+
+## Learn More
+
+- [FIR Risk Tuesday E89 — The April Inflection](/tuesday/e89-the-april-inflection/) — The seven-day window and the three downstream channels
+- [FIR Risk Tuesday E77 — Wiz CISO Budget Survey](/tuesday/e77-wiz-ciso-budget-survey/) — Tool sprawl context (58% run 25+ tools)
+- [Anthropic — Project Glasswing](https://www.anthropic.com/glasswing) — Coalition partner list and capability evidence
+- [OpenAI — Trusted Access for Cyber Defense](https://openai.com/index/scaling-trusted-access-for-cyber-defense/) — Verified-defender deployment vehicle
+
+---
+
+*Powered by [FIR Risk Platform](https://firrisk.ai/platform/) — AI-driven threat intelligence for enterprise risk leaders.*

--- a/content/intel/intel-21-contract-restructuring-window.md
+++ b/content/intel/intel-21-contract-restructuring-window.md
@@ -1,0 +1,61 @@
+---
+title: "INTEL-21: The Contract Restructuring Window"
+description: "The April 16–23 window changed something cyber vendors do not want priced into procurement: the cadence of frontier-AI defender upgrades just shifted, and no one can predict when the next release lands. Multi-year contracts assumed a slow capability curve — that assumption was invalidated in seven days. The action: at the next renewal or RFP, replace the 36-month-with-annual default with a four-element template — shorter base term, capability-uplift commitments at every renewal, AI-derived-capability roadmap disclosure, and exit clauses tied to defender-tool generations."
+date: 2026-04-30
+type: "intel"
+intel_type: "TREND"
+tags: ["Vendor Management", "Procurement", "Contract Architecture", "AI Defense", "Glasswing", "GPT-5.5", "CFO", "CISO", "Cyber Spend", "Risk Management", "Board Governance"]
+---
+
+## The INTEL
+
+**The April 16–23 window changed something cyber vendors do not want priced into procurement: the cadence of frontier-AI defender upgrades just shifted, and no one can predict when the next release lands.**
+
+Anthropic shipped Claude Mythos Preview and Project Glasswing on April 16. OpenAI shipped GPT-5.5 and Trusted Access for Cyber on April 23. Two competing US frontier-model labs delivered defensive AI uplift in seven days. The next release could be in weeks. Or longer. The point is the cadence: cyber vendors selling multi-year contracts on the assumption that today's differentiation will hold are pricing against an upgrade rhythm that no longer cooperates.
+
+For buyers, that strengthens the case for restructuring contract architecture *now* — before the next release demonstrates that capability priced into a 36-month commitment is already a generation behind.
+
+---
+
+## Why It Matters
+
+Multi-year cybersecurity contracts have long been the procurement default. They offer predictable budgets, simplified renewal cycles, and term-length leverage for vendors. The assumption underneath was a slow, predictable capability-improvement curve. The April inflection invalidated that assumption in seven days.
+
+The buyers most exposed are those who just signed (or are about to sign) 24–36 month deals with traditional pricing structures and no AI-uplift commitments — they are paying pre-inflection prices for a cyber-vendor market that is now under continuous upgrade pressure. The buyers most positioned are those who restructure contract architecture this quarter, while leverage is highest and the inflection is still recent enough to be a procurement conversation rather than a renewal-cycle surprise.
+
+The downside risk of waiting is asymmetric. If the next frontier release lands in weeks and reshapes the defender-tool market again, locked-in contracts become budgeted-but-stranded capability — capacity you've paid for that the market has moved past.
+
+---
+
+## What To Do — One Key Action
+
+**At the next contract renewal or vendor RFP for any cyber or security tool, replace the standard 36-month-with-annual-renewal structure with this four-element template:**
+
+→ **Shorter base term — 12 months,** with explicit re-evaluation triggers tied to capability shifts (not just calendar dates)
+→ **Capability-uplift commitments at every renewal** — written into the contract, not the SLA. Vendor commits to surfacing what coalition-derived or frontier-model-derived defensive capability has shipped, with what gating, since last renewal
+→ **AI-derived-capability roadmap disclosure** — vendor publishes (under NDA if needed) a 90-day forward roadmap for AI-defensive-capability releases at each renewal cycle
+→ **Exit clauses tied to defender-tool generations** — if the frontier ships a defender-relevant capability the vendor does not carry within 90 days, the buyer triggers re-evaluation without penalty
+
+This is a CFO + CISO joint move. The CFO sees the financial discipline (shorter terms, fewer locked commitments, clearer exit rights). The CISO sees the operational protection (uplift commitments, capability-tied triggers). The Board approves the architecture as a cyber-spend governance pattern, applied at every renewal cycle going forward.
+
+Vendors that accept this structure are signaling they expect to ship capability at frontier cadence and want to compete on it. Vendors that resist are signaling the opposite — and the resistance itself becomes useful procurement information.
+
+---
+
+## MITRE ATT&CK
+
+- **T1199 — Trusted Relationship:** The cyber-vendor contract is the formal architecture of the trust relationship. Restructuring contract terms is restructuring the trust audit at the procurement level — defender-tool generations become a legible cycle that procurement can govern.
+
+---
+
+## Learn More
+
+- [FIR Risk Tuesday E89 — The April Inflection](/tuesday/e89-the-april-inflection/) — Full inflection thesis and three economic shifts
+- [FIR Risk INTEL-20 — The Vendor Pressure Audit](/intel/intel-20-vendor-pressure-audit/) — The QBR question paired with this restructuring
+- [Anthropic — Project Glasswing](https://www.anthropic.com/glasswing) — April 16 announcement
+- [OpenAI — Introducing GPT-5.5](https://openai.com/index/introducing-gpt-5-5/) — April 23 announcement
+- [OpenAI — Trusted Access for Cyber Defense](https://openai.com/index/scaling-trusted-access-for-cyber-defense/) — Verified-defender deployment vehicle
+
+---
+
+*Powered by [FIR Risk Platform](https://firrisk.ai/platform/) — AI-driven threat intelligence for enterprise risk leaders.*


### PR DESCRIPTION
## Summary

Publishes INTEL-20 and INTEL-21 to firrisk.ai a day ahead of social posts. Both are E89 follow-ups — the buyer-side governance response to the April 16–23 frontier-AI defender inflection.

**Companion (already merged):**
- stikman28/fir-risk-intelligence#5 — E89 newsletter (live)
- stikman28/fir-risk-intelligence#6 — INTEL-20/21 source files + scheduler queue
- stikman28/fir-risk-website#4 — E89 website publish (live)

## INTEL-20 — The Vendor Pressure Audit (Wed Apr 29, TREND)

- **Action:** Recurring QBR question — *"What's your timeline for shipping Glasswing/TAC-derived AI defensive capability into our existing license tier — and what's the mechanism: feature flag, tier upgrade, separate SKU, or public roadmap?"*
- **Audience:** CISO + Procurement + Board
- **Anchor:** Glasswing partner list (most enterprises are already inside the coalition through their existing security stack) + Wiz tool-sprawl finding (58% of organizations run 25+ tools)

## INTEL-21 — The Contract Restructuring Window (Thu Apr 30, TREND)

- **Action:** At next renewal/RFP, replace the 36-month-with-annual default with a four-element template:
  1. Shorter base term — 12 months, with capability-shift triggers (not just calendar dates)
  2. Capability-uplift commitments at every renewal — written into the contract, not the SLA
  3. AI-derived-capability roadmap disclosure at renewal cycles
  4. Exit clauses tied to defender-tool generations (90-day window if frontier ships a capability the vendor doesn't carry)
- **Audience:** CFO + CISO + Board
- **Anchor:** April 16–23 frontier release cadence (Anthropic Glasswing/Opus 4.7 + OpenAI GPT-5.5/TAC in seven days)

## Files

- `content/intel/intel-20-vendor-pressure-audit.md` — Hugo page, no thumbnail (per current INTEL house rule — text-only since INTEL-19)
- `content/intel/intel-21-contract-restructuring-window.md` — Hugo page, no thumbnail

## What's NOT in this PR (auto-handled)

- **No images** — INTEL pieces no longer use hero images (rule established 2026-04-27); front matter omits \`thumbnail:\`
- **No Tuesday card update** — INTELs don't change the home page hero card (Tuesday-only)
- **No \`_index.md\` updates** — Tuesday and INTEL listings auto-populate from dynamic Hugo templates (per commit \`0d60579\`)

## Build verification

\`hugo --gc\` ran clean:
- **548 pages** (E89 + INTEL-20/21 + paginator updates)
- **746 processed images** (no new image processing — no images added)
- **No errors**

## Test plan

- [ ] Cloudflare Pages builds clean from this branch
- [ ] Live URLs render: \`https://firrisk.ai/intel/intel-20-vendor-pressure-audit/\` and \`https://firrisk.ai/intel/intel-21-contract-restructuring-window/\`
- [ ] INTEL listing page at \`https://firrisk.ai/intel/\` shows INTEL-20/21 at the top (auto-generated)
- [ ] Cross-references resolve: E89, E77 (INTEL-20), E89 + INTEL-20 (INTEL-21)

## Timing

Goes live today (Apr 28) — a day ahead of:
- INTEL-20 social: Wed Apr 29 LinkedIn 07:00 ET / X 07:05 ET
- INTEL-21 social: Thu Apr 30 LinkedIn 07:00 ET / X 07:05 ET

🤖 Generated with [Claude Code](https://claude.com/claude-code)