### PR TITLE
content: Add INTEL-28 — The Ransom Bluff (firrisk.ai page)

### DIFF
--- a/content/intel/intel-28-the-ransom-bluff.md
+++ b/content/intel/intel-28-the-ransom-bluff.md
@@ -1,0 +1,52 @@
+---
+title: "INTEL-28: The Ransom Bluff"
+description: "The ransom economy is cracking. In the 2026 Verizon DBIR, 69% of ransomware victims refused to pay (up from 65/55/51% the prior years), the median ransom fell to $139,875 — and a cross-reference of leak-site 'victim' lists against actual crypto payments suggests only ~9% of publicly named victims ever pay. The lists are partly theater. The one move: pre-decide your ransom-payment posture at the board level, backed by a rehearsed recovery."
+date: 2026-07-03
+type: "intel"
+intel_type: "TREND"
+tags: ["Ransomware", "Extortion", "Incident Response", "Board Governance", "Cyber Resilience", "Verizon DBIR", "CISO", "MITRE ATT&CK", "Risk Management"]
+---
+## The INTEL
+
+**The ransom economy is cracking. Most victims now refuse to pay, the median ransom is falling, and the leak-site "victim" lists are partly theater — a cross-reference against actual cryptocurrency payments suggests only about 9% of the organizations publicly named ever pay. The menace is increasingly manufactured. Don't negotiate from fear.**
+
+The 2026 DBIR puts ransomware in 48% of breaches — still the dominant extortion play. But the trend underneath the headline is moving in the defender's favor. **69% of ransomware victims did not pay**, up from 65%, 55%, and 51% in the three prior years — a steady, multi-year refusal curve. As more victims hold the line, the economics soften: the **median ransom paid fell to $139,875, down from $150,000**.
+
+And the lists themselves are bluffing. When the DBIR cross-referenced the "victims" named on leak sites against actual cryptocurrency payments, the data suggests **only about 9% of publicly named victims actually pay** — meaning the lists are, in significant part, fabricated to manufacture menace. The wall of logos is pressure theater, not a payment record.
+
+---
+
+## Why It Matters
+
+The instinct in a ransomware event is to negotiate from a position of fear — your name is on a leak site, a countdown is running, and the assumption is that everyone in your position pays. The DBIR data says the opposite is now true. Most victims don't pay, fewer pay each year, and the leak-site lists that look like proof of a paying ecosystem are, by the 9% cross-reference, mostly manufactured menace. The pressure is real; the inevitability is not.
+
+That changes the decision the board should be making — and *when*. The worst time to decide your ransom-payment posture is at 2 a.m. with encryption spreading and a countdown on the screen. A no-pay decision made under that pressure is a decision made by the attacker. A no-pay decision made in advance, at the board level, backed by a rehearsed recovery plan, is a decision you can credibly hold when the call comes.
+
+The exposure is also more predictable than it feels. The DBIR found that **among ransomware victims who'd had a credential leak, 50% of those leaks occurred within 95 days before the attack** — extortion rarely arrives out of nowhere. The same fundamentals that keep you out of the breach data in the first place — credential hygiene, exposure management, tested recovery — are what let you treat a ransom demand as a known scenario rather than a crisis you're improvising through.
+
+---
+
+## What To Do — One Key Action
+
+**Decide your ransom-payment posture in advance — at the board level — and don't let a leak-site "victim" list negotiate for you. Pre-make the no-pay decision, write it down, and back it with a rehearsed recovery plan, so you can credibly hold the line under pressure instead of deciding from fear in the moment.**
+
+This is a strategic decision plus incident-response readiness, not a backup-tooling question. The point is not "do you have backups" — it's "has the board already decided, in calm conditions, what the organization will do, and has the response team rehearsed holding that line?" Most victims don't pay (69%), and only about 9% of publicly named victims actually do — the leak-site lists are partly fabricated to make refusal feel impossible. A posture decided in advance, with a tested recovery plan behind it, lets you read those lists for what they are: pressure, not destiny.
+
+This is a Board + CISO joint move. The board owns the decision and its accountability; the CISO owns the rehearsal that makes the decision credible under fire. It is the same discipline E90 argues for across the board — **stay consistent on the fundamentals**, decided ahead of time and executed the same way under pressure as in a tabletop. The full plan is in [E90](/tuesday/e90-refinement-not-revolution/); pre-deciding your ransom posture is where holding the line starts.
+
+---
+
+## MITRE ATT&CK
+
+- **T1486 — Data Encrypted for Impact:** Ransomware and extortion. The control posture is a pre-made, board-level no-pay decision backed by a rehearsed recovery plan — so the response is a known scenario, not a negotiation conducted from fear.
+
+---
+
+## Learn More
+
+- [FIR Risk Tuesday E90 — Refinement, Not Revolution](/tuesday/e90-refinement-not-revolution/) — The full 2026 DBIR breakdown
+- [2026 Verizon Data Breach Investigations Report](https://www.verizon.com/business/resources/reports/dbir/) — Primary source
+
+---
+
+*Powered by [FIR Risk Platform](https://firrisk.ai/platform/) — AI-driven threat intelligence for enterprise risk leaders.*


### PR DESCRIPTION
Text-only TREND page, date 2026-07-03, URL /intel/intel-28-the-ransom-bluff/. Ransom-economy-cracking angle; fact-checked vs DBIR (Figs 45-47). CF-live before Fri 7/3 7am ET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_018FUCDBtD1CKBMiKDuRvTzM